### PR TITLE
docs: add 2nd arg to fetch

### DIFF
--- a/docs/variables/fetch.rst
+++ b/docs/variables/fetch.rst
@@ -12,11 +12,12 @@ Usage:
 
 Arguments:
     * ``url`` **<required>** - The url to send the request to
+    * ``path`` **[optional]** - The path to the property in the response (JSON only)
 
 Example Command:
     **name**: !kanye
 
-    **response**: $(fetch https://api.kanye.rest/?format=text) - Kanye
+    **response**: $(fetch https://api.kanye.rest/ quote) - Kanye
 
     **output**::
 


### PR DESCRIPTION
Adds 2nd argument to the documentation for `$(fetch)`.

I've **assumed** that the 2nd argument is only valid for JSON responses, however do not know and have not tested this.
I'd appreciate if this could be verified.

#### Related
* Closes https://github.com/botisimo/botisimo-documentation/issues/3